### PR TITLE
The handled event does not exist

### DIFF
--- a/imageroot/state/eventsgw.conf
+++ b/imageroot/state/eventsgw.conf
@@ -1,2 +1,0 @@
-[commands]
-*/event/account-provider-credentials-updated = setup-ldap


### PR DESCRIPTION
Event account-provider-credentials-updated is never triggered.

Furthermore, eventsgw does not pass any argument to the setup-ldap command, which requires at least one.

