### PR TITLE
send to stdout

### DIFF
--- a/nextcloud/ns.config.php
+++ b/nextcloud/ns.config.php
@@ -4,5 +4,5 @@
 $CONFIG = array(
    'updatechecker' => false,
    'check_for_working_wellknown_setup' => false,
-   'logtype' => 'errorlog'
+   'log_type' => 'errorlog'
 );


### PR DESCRIPTION
nextcloud does not send to stdout its log, only in a file


once done we can find this in journald

`May 30 10:37:56 R1-pve.rocky9-pve.org nextcloud2[21958]: NOTICE: PHP message: [nextcloud][no app in context][2] {"reqId":"UYUbi29i25rVzRhKKFiK","level":2,"time":"2023-05-30T08:37:56+00:00","remoteAddr":"192.168.13.25","user":"--","app":"no app in context","method":"POST","url":"/login","message":"Login failed: stephdl@domain.com (Remote IP: 192.168.13.25)","userAgent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36","version":"26.0.1.1","data":[]}`

the logfile nextcloud.log is not more in the dat folder 

```
/var/www/html # ls  data/
admin                 appdata_ocvjsqsz0vaz  files_external        index.html
```
