### PR TITLE
NC26 requires X-Robots-Tag "noindex, nofollow" always;

### DIFF
--- a/imageroot/actions/create-module/20expandconfig
+++ b/imageroot/actions/create-module/20expandconfig
@@ -96,7 +96,7 @@ http {
         add_header X-Download-Options                   "noopen"        always;
         add_header X-Frame-Options                      "SAMEORIGIN"    always;
         add_header X-Permitted-Cross-Domain-Policies    "none"          always;
-        add_header X-Robots-Tag                         "none"          always;
+        add_header X-Robots-Tag                         "noindex, nofollow"          always;
         add_header X-XSS-Protection                     "1; mode=block" always;
 
         # Remove X-Powered-By, which is an information leak


### PR DESCRIPTION
With the upgrade to NC26, Nextcloud requires to use a different header with X-Robots-Tag

https://docs.nextcloud.com/server/latest/admin_manual/installation/nginx.html