### PR TITLE
Fix the collabora in nextcloud

### DIFF
--- a/imageroot/actions/configure-module/80configure_collabora
+++ b/imageroot/actions/configure-module/80configure_collabora
@@ -10,11 +10,11 @@ tls_verify=$(cat config.json | jq -r '.tls_verify_collabora // empty')
 
 if  [[ "$collabora_host" != "" ]]; then
     occ app:install richdocuments
-    occ config:app:set richdocuments wopi_url --value=https://$COLLABORA_HOST
-    if [[ "$tls_verify" == 'True' ]]; then
-        occ config:app:set richdocuments disable_certificate_verification --value=yes
-    else
+    occ config:app:set richdocuments wopi_url --value=https://$collabora_host
+    if [[ "$tls_verify" == 'true' ]]; then
         occ config:app:set richdocuments disable_certificate_verification --value=no
+    else
+        occ config:app:set richdocuments disable_certificate_verification --value=yes
     fi
     occ app:enable richdocuments
 fi

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -70,6 +70,10 @@ for c in rdb.scan_iter('module/collabora*/environment'):
     if url:
         array_collabora.append({"name": name, "label": name+' ('+ url+')', "value": url})
 config["array_collabora"] = array_collabora
+# The first load of nextcloud json is empty of tls_verify_collabora
+# let's do a default value
+if "tls_verify_collabora" not in config:
+    config["tls_verify_collabora"] = False
 
 # Dump the configuratio to stdou
 json.dump(config, fp=sys.stdout)


### PR DESCRIPTION
test of nextcloud 27.1.3 ok
test of collabora ok with the fix of this PR
smarthost are set in nextcloud

tested collabora with version 21.11.5.3 and 23.05.5.4.1 (new version from https://github.com/NethServer/ns8-collabora/pull/12)

first install or upgrade from 21.11.5.3 is good

![image](https://github.com/NethServer/ns8-nextcloud/assets/3164851/aad9c683-0f32-41a3-ba51-7792aefc3368)


the fix is needed to get a default value for `tls_verify_collabora` because nextcloud  is a special beast reading from a json file its configuration and like https://github.com/NethServer/ns8-nextcloud/blob/fixCollabora/imageroot/actions/get-configuration/20read#L38 for lets_encrypt if the file config.json file does not exist we except to a default value for `lets_encrypt`, then at the first save of the configuration we write it. Else except the first time you save true to  `tls_verify_collabora`, this property is not know by the UI because never initiated.