### PR TITLE
Disable web upgrade in ns.config.php

### DIFF
--- a/nextcloud/ns.config.php
+++ b/nextcloud/ns.config.php
@@ -2,6 +2,7 @@
 
 // NethServer config
 $CONFIG = array(
+   'upgrade.disable-web' => true,
    'updatechecker' => false,
    'check_for_working_wellknown_setup' => false,
    'log_type' => 'errorlog'


### PR DESCRIPTION
This pull request disables the web upgrade feature in the ns.config.php file. This change ensures that the upgrade functionality is disabled and prevents any accidental upgrades through the web interface.

NOTE: this will affect only new installation, previous installations are not impacted, we will continue to see the upgrade web proposal

![image](https://github.com/NethServer/ns8-nextcloud/assets/3164851/959277ad-9065-4fb4-92de-3e69707a127e)

https://github.com/NethServer/dev/issues/6807