### PR TITLE
Update user domain in translation.json

### DIFF
--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -32,7 +32,7 @@
     "instance_configuration": "Configure {instance}",
     "configuring": "Configuration in progress...",
     "lets_encrypt": "Let's Encrypt certificate",
-    "domain": "LDAP User domain",
+    "domain": "User domain",
     "no_domain": "No user domain",
     "host_string_gte": "The host name can't be empty",
     "configure_nextcloud": "Configure Nextcloud",
@@ -42,8 +42,8 @@
     "tls_verify_collabora":"Verify TLS certificate",
     "collabora_placeholder": "Select a collabora server or leave empty to disable",
     "admin_password": "Password for user 'admin'",
-    "domain_tooltip": "A LDAP domain is used to authenticate users. If none LDAP user domain is listed you probably need to install one",
-    "choose_ldap_domain": "Select a LDAP user domain",
+    "domain_tooltip": "A user domain is used to authenticate users. If none user domain is listed you probably need to install one",
+    "choose_ldap_domain": "Select a user domain",
     "host_placeholder": "E.g. mynextcloud.example.org"
   },
   "about": {


### PR DESCRIPTION
This pull request updates the user domain in the translation.json file. The "LDAP User domain" has been changed to "User domain" for better clarity and consistency.

https://github.com/NethServer/dev/issues/6806