### PR TITLE
Add "no_user_domain" option to domain list

### DIFF
--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -44,7 +44,8 @@
     "admin_password": "Password for user 'admin'",
     "domain_tooltip": "A user domain is used to authenticate users. If none user domain is listed you probably need to install one",
     "choose_ldap_domain": "Select a user domain",
-    "host_placeholder": "E.g. mynextcloud.example.org"
+    "host_placeholder": "E.g. mynextcloud.example.org",
+    "admin_password_tooltip": "The user 'admin' is the internal administrator of Nextcloud. This password is used to authenticate the 'admin' user in the Nextcloud web interface."
   },
   "about": {
     "title": "About"

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -33,7 +33,7 @@
     "configuring": "Configuration in progress...",
     "lets_encrypt": "Let's Encrypt certificate",
     "domain": "User domain",
-    "no_domain": "No user domain",
+    "no_user_domain": "Use the Nextcloud user database",
     "host_string_gte": "The host name can't be empty",
     "configure_nextcloud": "Configure Nextcloud",
     "host_invalid_type": "Invalid host name",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -33,7 +33,7 @@
     "configuring": "Configuration in progress...",
     "lets_encrypt": "Let's Encrypt certificate",
     "domain": "User domain",
-    "no_user_domain": "Use the Nextcloud user database",
+    "no_user_domain": "Nextcloud internal user database",
     "host_string_gte": "The host name can't be empty",
     "configure_nextcloud": "Configure Nextcloud",
     "host_invalid_type": "Invalid host name",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -42,7 +42,6 @@
     "tls_verify_collabora":"Verify TLS certificate",
     "collabora_placeholder": "Select a collabora server or leave empty to disable",
     "admin_password": "Password for user 'admin'",
-    "domain_tooltip": "A user domain is used to authenticate users. If none user domain is listed you probably need to install one",
     "choose_ldap_domain": "Select a user domain",
     "host_placeholder": "E.g. mynextcloud.example.org",
     "admin_password_tooltip": "The user 'admin' is the internal administrator of Nextcloud. This password is used to authenticate the 'admin' user in the Nextcloud web interface."

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -39,8 +39,9 @@
               ref="host"
             >
             </cv-text-input>
-            <cv-text-input
+             <NsTextInput
               :label="$t('settings.admin_password')"
+              type="password"
               v-model.trim="password"
               v-if="!installed"
               class="mg-bottom"
@@ -48,7 +49,12 @@
               :disabled="loadingUi"
               ref="password"
             >
-            </cv-text-input>
+              <template slot="tooltip">
+                <span
+                  v-html="$t('settings.admin_password_tooltip')"
+                ></span>
+              </template>
+            </NsTextInput>
             <cv-toggle
               value="letsEncrypt"
               :label="$t('settings.lets_encrypt')"

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -358,7 +358,7 @@ export default {
           data: {
             host: this.host,
             lets_encrypt: this.isLetsEncryptEnabled,
-            domain: this.domain,
+            domain: this.domain === "-" ? "" : this.domain,
             is_collabora: this.is_collabora,
             collabora_host: this.collabora_host,
             tls_verify_collabora: this.tls_verify_collabora,
@@ -396,7 +396,7 @@ export default {
       this.collabora_host = config.collabora_host;
       this.collabora_URL = config.array_collabora;
       this.loading.getConfiguration = false;
-      this.domain = config.domain;
+      this.domain = config.domain === "" ? "-" : config.domain;
       this.focusElement("host");
     },
     listUserDomainsCompleted(taskContext, taskResult) {
@@ -409,6 +409,12 @@ export default {
           value: element["name"],
         };
         this.domains.push(option);
+      });
+      //PUSH no domain option
+      this.domains.unshift({
+        name: "no_user_domain",
+        label: this.$t("settings.no_user_domain"),
+        value: "-"
       });
       this.loading.listUserDomains = false;
     },

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -315,6 +315,12 @@ export default {
         this.focusElement("domain");
         isValidationOk = false;
       }
+      if (!this.password) {
+        // test field cannot be empty
+        this.error.password = this.$t("common.required");
+        this.focusElement("password");
+        isValidationOk = false;
+      }
       // exclude characters not correctly supported by env file
       const re = new RegExp("\"|=|'|\\s|\\t");
       if (re.test(this.password)) {

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -82,11 +82,6 @@
               tooltipDirection="top"
               ref="domain"
             >
-            <template slot="tooltip">
-                {{
-                  $t("settings.domain_tooltip")
-                }}
-                </template>
             </NsComboBox>
             <template v-if="is_collabora && installed">
               <NsComboBox


### PR DESCRIPTION
This pull request adds a new option, "no_user_domain", to the domain list in the translation.json file. It also updates the Settings.vue component to include a password validation and a tooltip for the admin password input.

![Capture d’écran du 2023-12-21 14-11-22](https://github.com/NethServer/ns8-nextcloud/assets/3164851/60db76e4-0989-4b17-bcbd-e98b1935bade)

![Capture d’écran du 2023-12-21 16-31-11](https://github.com/NethServer/ns8-nextcloud/assets/3164851/1731ee36-e8ed-4adf-a3a8-1061c275f0d8)

![Capture d’écran du 2023-12-21 16-31-26](https://github.com/NethServer/ns8-nextcloud/assets/3164851/fc9b0d38-5b49-4bdb-a58e-b262414cc01a)

![Capture d’écran du 2023-12-21 16-31-36](https://github.com/NethServer/ns8-nextcloud/assets/3164851/05c4fe87-516f-44f0-bae6-ebf9a10104dc)

https://github.com/NethServer/dev/issues/6806