### PR TITLE
Fix typo in ExecStartPost command

### DIFF
--- a/imageroot/systemd/user/nextcloud-app.service
+++ b/imageroot/systemd/user/nextcloud-app.service
@@ -11,7 +11,7 @@ Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/nextcloud-app.pid %t/nextcloud-app.ctr-id
 ExecStartPre=-runagent discover-smarthost
-ExecStartPost=runagent wait_startup
+ExecStartPost=runagent wait-startup
 ExecStartPost=runagent setup-smtp
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/nextcloud-app.pid --cidfile %t/nextcloud-app.ctr-id --cgroups=no-conmon --pod-id-file %t/nextcloud.pod-id --replace -d --name nextcloud-app --env-file=%S/state/config.env --env-file=%S/state/smarthost.env -v nextcloud-app-data:/var/www/html -v %S/state/zzz_nethserver.conf:/usr/local/etc/php-fpm.d/zzz_nethserver.conf:z ${NEXTCLOUD_APP_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/nextcloud-app.ctr-id -t 10


### PR DESCRIPTION
This pull request fixes a typo in the `ExecStartPost` command of the `nextcloud-app.service` file. The command was previously `runagent wait_startup` and has been corrected to `runagent wait-startup`. This typo caused issues during the startup process.

https://github.com/NethServer/dev/issues/6817