### PR TITLE
Update Nextcloud version to 27.1.9 and other dependencies

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -3,7 +3,7 @@
 # Terminate on error
 set -e
 
-NC_VERSION=27.1.7
+NC_VERSION=27.1.9
 
 # Prepare variables for later use
 images=()


### PR DESCRIPTION
This pull request updates the Nextcloud version to 27.1.9 and also updates other dependencies such as MariaDB to version 10.6.18 and NGINX to version 1.26.0-alpine.

as a side note nextcloud 28.xxx is available but [php8.2 is recommended](https://docs.nextcloud.com/server/latest/admin_manual/release_notes/upgrade_to_28.html)


first install and upgrade to this version are good

LDAP ok
basic authentication OK