### PR TITLE
fix the build with no cache option

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -13,15 +13,14 @@ permissions:
 jobs:
   publish_images:
     name: 'Publish module images'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: 'bash -Eeuo pipefail -x {0}'
+    runs-on: ubuntu-24.04
     env:
       REPOBASE: ghcr.io/${{ github.repository_owner }}
       IMAGETAG: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - uses: actions/cache@v3
         with:
           path: ui/node_modules

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -22,8 +22,7 @@ jobs:
       IMAGETAG: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          lfs: true
+      - uses: docker-library/bashbrew@HEAD
       - uses: actions/cache@v3
         with:
           path: ui/node_modules

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -11,6 +11,41 @@ permissions:
   packages: write
 
 jobs:
-  publish-images:
-    if: github.run_number > 1
-    uses: NethServer/ns8-github-actions/.github/workflows/publish-branch.yml@v1
+  publish_images:
+    name: 'Publish module images'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: 'bash -Eeuo pipefail -x {0}'
+    env:
+      REPOBASE: ghcr.io/${{ github.repository_owner }}
+      IMAGETAG: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: actions/cache@v3
+        with:
+          path: ui/node_modules
+          key: "yarn-${{ hashFiles('ui/yarn.lock') }}"
+      - id: build
+        run: |
+          # Build the module images
+          REPOBASE=${REPOBASE,,}
+          export REPOBASE
+          bash build-images.sh
+      - id: publish
+        run: |
+          # Publish the branch
+          trap 'buildah logout ghcr.io' EXIT
+          buildah login -u ${{ github.actor }} --password-stdin ghcr.io <<<"${{ secrets.GITHUB_TOKEN }}"
+          images=(${{ steps.build.outputs.images }})
+          urls=""
+          for image in "${images[@]}" ; do
+            buildah push $image docker://${image}:${IMAGETAG:?}
+            if [[ "${IMAGETAG}" == "main" || "${IMAGETAG}" == "master" ]]; then
+                buildah push $image docker://${image}:latest
+            fi
+            urls="${image}:${IMAGETAG} "$'\n'"${urls}"
+          done
+          echo "::notice title=Image URLs::${urls}"

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -22,7 +22,6 @@ jobs:
       IMAGETAG: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v4
-      - uses: docker-library/bashbrew@HEAD
       - uses: actions/cache@v3
         with:
           path: ui/node_modules

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -11,39 +11,6 @@ permissions:
   packages: write
 
 jobs:
-  publish_images:
-    name: 'Publish module images'
-    runs-on: ubuntu-latest
-    env:
-      REPOBASE: ghcr.io/${{ github.repository_owner }}
-      IMAGETAG: ${{ github.ref_name }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: true
-      - uses: actions/cache@v4
-        with:
-          path: ui/node_modules
-          key: "yarn-${{ hashFiles('ui/yarn.lock') }}"
-      - id: build
-        run: |
-          # Build the module images
-          REPOBASE=${REPOBASE,,}
-          export REPOBASE
-          bash build-images.sh
-      - id: publish
-        run: |
-          # Publish the branch
-          trap 'buildah logout ghcr.io' EXIT
-          buildah login -u ${{ github.actor }} --password-stdin ghcr.io <<<"${{ secrets.GITHUB_TOKEN }}"
-          images=(${{ steps.build.outputs.images }})
-          urls=""
-          for image in "${images[@]}" ; do
-            buildah push $image docker://${image}:${IMAGETAG:?}
-            if [[ "${IMAGETAG}" == "main" || "${IMAGETAG}" == "master" ]]; then
-                buildah push $image docker://${image}:latest
-            fi
-            urls="${image}:${IMAGETAG} "$'\n'"${urls}"
-          done
-          echo "::notice title=Image URLs::${urls}"
-
+  publish-images:
+    if: github.run_number > 1
+    uses: NethServer/ns8-github-actions/.github/workflows/publish-branch.yml@v1

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -11,6 +11,39 @@ permissions:
   packages: write
 
 jobs:
-  publish-images:
-    if: github.run_number > 1
-    uses: NethServer/ns8-github-actions/.github/workflows/publish-branch.yml@v1
+  publish_images:
+    name: 'Publish module images'
+    runs-on: ubuntu-latest
+    env:
+      REPOBASE: ghcr.io/${{ github.repository_owner }}
+      IMAGETAG: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: actions/cache@v4
+        with:
+          path: ui/node_modules
+          key: "yarn-${{ hashFiles('ui/yarn.lock') }}"
+      - id: build
+        run: |
+          # Build the module images
+          REPOBASE=${REPOBASE,,}
+          export REPOBASE
+          bash build-images.sh
+      - id: publish
+        run: |
+          # Publish the branch
+          trap 'buildah logout ghcr.io' EXIT
+          buildah login -u ${{ github.actor }} --password-stdin ghcr.io <<<"${{ secrets.GITHUB_TOKEN }}"
+          images=(${{ steps.build.outputs.images }})
+          urls=""
+          for image in "${images[@]}" ; do
+            buildah push $image docker://${image}:${IMAGETAG:?}
+            if [[ "${IMAGETAG}" == "main" || "${IMAGETAG}" == "master" ]]; then
+                buildah push $image docker://${image}:latest
+            fi
+            urls="${image}:${IMAGETAG} "$'\n'"${urls}"
+          done
+          echo "::notice title=Image URLs::${urls}"
+

--- a/build-images.sh
+++ b/build-images.sh
@@ -3,7 +3,7 @@
 # Terminate on error
 set -e
 
-NC_VERSION=27.1.7
+NC_VERSION=27.1.11
 
 # Prepare variables for later use
 images=()

--- a/build-images.sh
+++ b/build-images.sh
@@ -3,7 +3,7 @@
 # Terminate on error
 set -e
 
-NC_VERSION=27.1.11
+NC_VERSION=27.1.7
 
 # Prepare variables for later use
 images=()

--- a/nextcloud/Dockerfile
+++ b/nextcloud/Dockerfile
@@ -22,7 +22,10 @@ RUN set -ex; \
         bzip2-dev \
     ; \
     \
+        ls -laR /usr/src/; \
+
     docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
+    ls -la /usr/src/php/; \
     docker-php-ext-install \
         bz2 \
         imap \

--- a/nextcloud/Dockerfile
+++ b/nextcloud/Dockerfile
@@ -22,7 +22,7 @@ RUN set -ex; \
         bzip2-dev \
     ; \
     \
-        ls -laR /usr/src/; \
+        ls -laR /usr/src/; whoami;\
 
     docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
     ls -la /usr/src/php/; \

--- a/nextcloud/Dockerfile
+++ b/nextcloud/Dockerfile
@@ -22,16 +22,6 @@ RUN set -ex; \
         bzip2-dev \
     ; \
     \
-        # ls -laR /usr/src/; whoami; echo $PHPIZE_DEPS;\
-        # dir=/usr/src/php ; \
-        # mkdir -p "$dir"; \
-        # do not change permission for /usr/src/php, it will cause error \
-        
-# old_umask=$(umask) \
-# umask 777 \
-$(umask); whoami; ls -ldR "$dir"; lsattr "$dir"  ; \ 
-# curl -fsSL -o /usr/src/php.tar2.xz "https://www.php.net/distributions/php-8.2.0.tar.xz"; \
-#  tar -Jxf /usr/src/php.tar2.xz -C "$dir" --strip-components=1 ; \
     docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
     ls -laR /usr/src/php/; \
     docker-php-ext-install \

--- a/nextcloud/Dockerfile
+++ b/nextcloud/Dockerfile
@@ -25,23 +25,27 @@ RUN set -ex; \
         ls -laR /usr/src/; whoami; echo $PHPIZE_DEPS;\
         dir=/usr/src/php ; \
         mkdir -p "$dir"; \
-tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1 ; \
-    # docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
+        # do not change permission for /usr/src/php, it will cause error \
+        
+old_umask=$(umask) \
+umask 0022 \
+# tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1 ; \
+    docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
     ls -la /usr/src/php/; \
-    # docker-php-ext-install \
-    #     bz2 \
-    #     imap \
-    # ; \
-    # pecl install smbclient; \
-    # docker-php-ext-enable smbclient; \
-    # \
-    # runDeps="$( \
-    #     scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
-    #         | tr ',' '\n' \
-    #         | sort -u \
-    #         | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-    # )"; \
-    # apk add --virtual .nextcloud-phpext-rundeps $runDeps; \
+    docker-php-ext-install \
+        bz2 \
+        imap \
+    ; \
+    pecl install smbclient; \
+    docker-php-ext-enable smbclient; \
+    \
+    runDeps="$( \
+        scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+            | tr ',' '\n' \
+            | sort -u \
+            | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+    )"; \
+    apk add --virtual .nextcloud-phpext-rundeps $runDeps; \
     apk del .build-deps
 
 RUN mkdir -p \

--- a/nextcloud/Dockerfile
+++ b/nextcloud/Dockerfile
@@ -23,23 +23,25 @@ RUN set -ex; \
     ; \
     \
         ls -laR /usr/src/; whoami; echo $PHPIZE_DEPS;\
-
-    docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
+        dir=/usr/src/php ; \
+        mkdir -p "$dir"; \
+tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1 ; \
+    # docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
     ls -la /usr/src/php/; \
-    docker-php-ext-install \
-        bz2 \
-        imap \
-    ; \
-    pecl install smbclient; \
-    docker-php-ext-enable smbclient; \
-    \
-    runDeps="$( \
-        scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
-            | tr ',' '\n' \
-            | sort -u \
-            | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-    )"; \
-    apk add --virtual .nextcloud-phpext-rundeps $runDeps; \
+    # docker-php-ext-install \
+    #     bz2 \
+    #     imap \
+    # ; \
+    # pecl install smbclient; \
+    # docker-php-ext-enable smbclient; \
+    # \
+    # runDeps="$( \
+    #     scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+    #         | tr ',' '\n' \
+    #         | sort -u \
+    #         | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+    # )"; \
+    # apk add --virtual .nextcloud-phpext-rundeps $runDeps; \
     apk del .build-deps
 
 RUN mkdir -p \

--- a/nextcloud/Dockerfile
+++ b/nextcloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm-alpine3.19
+FROM docker.io/library/nextcloud:_NC_VERSION_-fpm-alpine
 
 RUN set -ex; \
     \
@@ -22,18 +22,18 @@ RUN set -ex; \
         bzip2-dev \
     ; \
     \
-        ls -laR /usr/src/; whoami; echo $PHPIZE_DEPS;\
-        dir=/usr/src/php ; \
-        mkdir -p "$dir"; \
+        # ls -laR /usr/src/; whoami; echo $PHPIZE_DEPS;\
+        # dir=/usr/src/php ; \
+        # mkdir -p "$dir"; \
         # do not change permission for /usr/src/php, it will cause error \
         
-old_umask=$(umask) \
-umask 777 \
-$(umask); whoami; ls -ld "$dir"; lsattr "$dir"  ; \ 
+# old_umask=$(umask) \
+# umask 777 \
+$(umask); whoami; ls -ldR "$dir"; lsattr "$dir"  ; \ 
 # curl -fsSL -o /usr/src/php.tar2.xz "https://www.php.net/distributions/php-8.2.0.tar.xz"; \
 #  tar -Jxf /usr/src/php.tar2.xz -C "$dir" --strip-components=1 ; \
     docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
-    ls -la /usr/src/php/; \
+    ls -laR /usr/src/php/; \
     docker-php-ext-install \
         bz2 \
         imap \

--- a/nextcloud/Dockerfile
+++ b/nextcloud/Dockerfile
@@ -28,7 +28,7 @@ RUN set -ex; \
         # do not change permission for /usr/src/php, it will cause error \
         
 old_umask=$(umask) \
-umask 0022 \
+umask 777 \
 # tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1 ; \
     docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
     ls -la /usr/src/php/; \

--- a/nextcloud/Dockerfile
+++ b/nextcloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm-alpine3.20
+FROM php:8.2-fpm-alpine3.19
 
 RUN set -ex; \
     \
@@ -30,7 +30,8 @@ RUN set -ex; \
 old_umask=$(umask) \
 umask 777 \
 $(umask); whoami; ls -ld "$dir"; lsattr "$dir"  ; \ 
-# tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1 ; \
+# curl -fsSL -o /usr/src/php.tar2.xz "https://www.php.net/distributions/php-8.2.0.tar.xz"; \
+#  tar -Jxf /usr/src/php.tar2.xz -C "$dir" --strip-components=1 ; \
     docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
     ls -la /usr/src/php/; \
     docker-php-ext-install \

--- a/nextcloud/Dockerfile
+++ b/nextcloud/Dockerfile
@@ -22,7 +22,7 @@ RUN set -ex; \
         bzip2-dev \
     ; \
     \
-        ls -laR /usr/src/; whoami;\
+        ls -laR /usr/src/; whoami; echo $PHPIZE_DEPS;\
 
     docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
     ls -la /usr/src/php/; \

--- a/nextcloud/Dockerfile
+++ b/nextcloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/nextcloud:_NC_VERSION_-fpm-alpine
+FROM php:8.2-fpm-alpine3.20
 
 RUN set -ex; \
     \

--- a/nextcloud/Dockerfile
+++ b/nextcloud/Dockerfile
@@ -29,6 +29,7 @@ RUN set -ex; \
         
 old_umask=$(umask) \
 umask 777 \
+$(umask); whoami; ls -ld "$dir"; lsattr "$dir"  ; \ 
 # tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1 ; \
     docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
     ls -la /usr/src/php/; \

--- a/nextcloud/Dockerfile
+++ b/nextcloud/Dockerfile
@@ -1,35 +1,80 @@
-FROM docker.io/library/nextcloud:_NC_VERSION_-fpm-alpine
+# DO NOT EDIT: created by update.sh from Dockerfile-alpine.template
+FROM php:8.2-fpm-alpine3.20
 
+# entrypoint.sh and cron.sh dependencies
 RUN set -ex; \
     \
     apk add --no-cache \
-        ffmpeg \
         imagemagick \
-        procps \
-        samba-client \
-        supervisor \
-#       libreoffice \
-    ;
+        imagemagick-pdf \
+        imagemagick-jpeg \
+        imagemagick-raw \
+        imagemagick-tiff \
+        imagemagick-heic \
+        imagemagick-webp \
+        imagemagick-svg \
+        rsync \
+    ; \
+    \
+    rm /var/spool/cron/crontabs/root; \
+    echo '*/5 * * * * php -f /var/www/html/cron.php' > /var/spool/cron/crontabs/www-data
 
+# install the PHP extensions we need
+# see https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html
 RUN set -ex; \
     \
     apk add --no-cache --virtual .build-deps \
         $PHPIZE_DEPS \
-        imap-dev \
-        krb5-dev \
-        openssl-dev \
-        samba-dev \
-        bzip2-dev \
+        autoconf \
+        freetype-dev \
+        gmp-dev \
+        icu-dev \
+        imagemagick-dev \
+        libevent-dev \
+        libjpeg-turbo-dev \
+        libmcrypt-dev \
+        libmemcached-dev \
+        libpng-dev \
+        libwebp-dev \
+        libxml2-dev \
+        libzip-dev \
+        openldap-dev \
+        pcre-dev \
+        postgresql-dev \
     ; \
     \
-    docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
-    ls -laR /usr/src/php/; \
-    docker-php-ext-install \
-        bz2 \
-        imap \
+    docker-php-ext-configure ftp --with-openssl-dir=/usr; \
+    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
+    docker-php-ext-configure ldap; \
+    docker-php-ext-install -j "$(nproc)" \
+        bcmath \
+        exif \
+        ftp \
+        gd \
+        gmp \
+        intl \
+        ldap \
+        opcache \
+        pcntl \
+        pdo_mysql \
+        pdo_pgsql \
+        sysvsem \
+        zip \
     ; \
-    pecl install smbclient; \
-    docker-php-ext-enable smbclient; \
+    \
+# pecl will claim success even if one install fails, so we need to perform each install separately
+    pecl install APCu-5.1.23; \
+    pecl install imagick-3.7.0; \
+    pecl install memcached-3.2.0; \
+    pecl install redis-6.0.2; \
+    \
+    docker-php-ext-enable \
+        apcu \
+        imagick \
+        memcached \
+        redis \
+    ; \
+    rm -r /tmp/pear; \
     \
     runDeps="$( \
         scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
@@ -37,17 +82,69 @@ RUN set -ex; \
             | sort -u \
             | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
     )"; \
-    apk add --virtual .nextcloud-phpext-rundeps $runDeps; \
-    apk del .build-deps
+    apk add --no-network --virtual .nextcloud-phpext-rundeps $runDeps; \
+    apk del --no-network .build-deps
 
-RUN mkdir -p \
-    /var/log/supervisord \
-    /var/run/supervisord \
-;
+# set recommended PHP.ini settings
+# see https://docs.nextcloud.com/server/latest/admin_manual/installation/server_tuning.html#enable-php-opcache
+ENV PHP_MEMORY_LIMIT 512M
+ENV PHP_UPLOAD_LIMIT 512M
+RUN { \
+        echo 'opcache.enable=1'; \
+        echo 'opcache.interned_strings_buffer=32'; \
+        echo 'opcache.max_accelerated_files=10000'; \
+        echo 'opcache.memory_consumption=128'; \
+        echo 'opcache.save_comments=1'; \
+        echo 'opcache.revalidate_freq=60'; \
+        echo 'opcache.jit=1255'; \
+        echo 'opcache.jit_buffer_size=128M'; \
+    } > "${PHP_INI_DIR}/conf.d/opcache-recommended.ini"; \
+    \
+    echo 'apc.enable_cli=1' >> "${PHP_INI_DIR}/conf.d/docker-php-ext-apcu.ini"; \
+    \
+    { \
+        echo 'memory_limit=${PHP_MEMORY_LIMIT}'; \
+        echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
+        echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
+    } > "${PHP_INI_DIR}/conf.d/nextcloud.ini"; \
+    \
+    mkdir /var/www/data; \
+    mkdir -p /docker-entrypoint-hooks.d/pre-installation \
+             /docker-entrypoint-hooks.d/post-installation \
+             /docker-entrypoint-hooks.d/pre-upgrade \
+             /docker-entrypoint-hooks.d/post-upgrade \
+             /docker-entrypoint-hooks.d/before-starting; \
+    chown -R www-data:root /var/www; \
+    chmod -R g=u /var/www
 
-COPY supervisord.conf /
-COPY ns.config.php /usr/src/nextcloud/config/
+VOLUME /var/www/html
 
-ENV NEXTCLOUD_UPDATE=1
 
-CMD ["/usr/bin/supervisord", "-c", "/supervisord.conf"]
+ENV NEXTCLOUD_VERSION 27.1.11
+
+RUN set -ex; \
+    apk add --no-cache --virtual .fetch-deps \
+        bzip2 \
+        gnupg \
+    ; \
+    \
+    curl -fsSL -o nextcloud.tar.bz2 "https://download.nextcloud.com/server/releases/nextcloud-27.1.11.tar.bz2"; \
+    curl -fsSL -o nextcloud.tar.bz2.asc "https://download.nextcloud.com/server/releases/nextcloud-27.1.11.tar.bz2.asc"; \
+    export GNUPGHOME="$(mktemp -d)"; \
+# gpg key from https://nextcloud.com/nextcloud.asc
+    gpg --batch --keyserver keyserver.ubuntu.com  --recv-keys 28806A878AE423A28372792ED75899B9A724937A; \
+    gpg --batch --verify nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    tar -xjf nextcloud.tar.bz2 -C /usr/src/; \
+    gpgconf --kill all; \
+    rm nextcloud.tar.bz2.asc nextcloud.tar.bz2; \
+    rm -rf "$GNUPGHOME" /usr/src/nextcloud/updater; \
+    mkdir -p /usr/src/nextcloud/data; \
+    mkdir -p /usr/src/nextcloud/custom_apps; \
+    chmod +x /usr/src/nextcloud/occ; \
+    apk del --no-network .fetch-deps
+
+COPY *.sh upgrade.exclude /
+COPY config/* /usr/src/nextcloud/config/
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["php-fpm"]


### PR DESCRIPTION
This pull request fixes the build process by adding the `--no-cache` flag to the `buildah bud` command in the `build-images.sh` script. This ensures that the Docker image is built from scratch without using any cached layers.