### PR TITLE
Update publish-images.yml to use stephdl/ns8-github-actions and add runner-version parameter

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -14,5 +14,3 @@ jobs:
   publish-images:
     if: github.run_number > 1
     uses: stephdl/ns8-github-actions/.github/workflows/publish-branch.yml@v1
-    with:
-      runner-version: ubuntu-latest"

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -13,4 +13,6 @@ permissions:
 jobs:
   publish-images:
     if: github.run_number > 1
-    uses: stephdl/ns8-github-actions/.github/workflows/publish-branch.yml@v1
+    uses: stephdl/ns8-github-actions/.github/workflows/publish-branch.yml@main
+    with:
+      runner-version: ubuntu-24.04

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -13,4 +13,6 @@ permissions:
 jobs:
   publish-images:
     if: github.run_number > 1
-    uses: NethServer/ns8-github-actions/.github/workflows/publish-branch.yml@v1
+    uses: stephdl/ns8-github-actions/.github/workflows/publish-branch.yml@v1
+    with:
+      runner-version: ubuntu-latest"


### PR DESCRIPTION
This pull request updates the `publish-images.yml` file to use the `stephdl/ns8-github-actions` repository instead of `NethServer/ns8-github-actions`. It also adds a new `runner-version` parameter to the workflow. This change ensures that the latest version of the runner is used for the workflow.