### PR TITLE
Add reverse proxy settings for static files in nginx configuration

### DIFF
--- a/imageroot/actions/create-module/20expandconfig
+++ b/imageroot/actions/create-module/20expandconfig
@@ -220,6 +220,16 @@ http {
         location / {
             try_files $uri $uri/ /index.php$request_uri;
         }
+        # reverse proxy stuff
+        location / {
+            add_header       X-Served-By $host;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-Scheme $scheme;
+            proxy_set_header X-Forwarded-Proto  $scheme;
+            proxy_set_header X-Forwarded-For    $remote_addr;
+            proxy_set_header X-Real-IP          $remote_addr;
+            proxy_pass       $forward_scheme://$server:$port$request_uri;
+        }
     }
 }
 EOF


### PR DESCRIPTION
This pull request adds reverse proxy settings for static files in the nginx configuration. The new settings include headers for X-Served-By, X-Forwarded-Scheme, X-Forwarded-Proto, X-Forwarded-For, and X-Real-IP. These settings allow for proper handling of reverse proxy requests.