### PR TITLE
Update MariaDB and Nginx versions in build script

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -32,7 +32,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=traefik@any:routeadm cluster:accountconsumer" \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
-    --label="org.nethserver.images=docker.io/redis:6.2.12-alpine docker.io/mariadb:10.6.19 docker.io/nginx:1.27.1-alpine ghcr.io/nethserver/nextcloud-app:${IMAGETAG}" \
+    --label="org.nethserver.images=docker.io/redis:6.2.12-alpine docker.io/mariadb:10.6.20 docker.io/nginx:1.27.3-alpine ghcr.io/nethserver/nextcloud-app:${IMAGETAG}" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"


### PR DESCRIPTION
Upgrade the versions of MariaDB and Nginx in the build script to ensure compatibility and access to the latest features.

https://github.com/NethServer/dev/issues/7206