### PR TITLE
Remove duplicated WASM mime type from Nginx config

### DIFF
--- a/imageroot/actions/create-module/20expandconfig
+++ b/imageroot/actions/create-module/20expandconfig
@@ -38,7 +38,6 @@ http {
     # Set .mjs and wasm that is missing in the mime.types
     types {
         text/javascript mjs;
-        application/wasm wasm;
     }
     default_type  application/octet-stream;
 

--- a/imageroot/actions/create-module/20expandconfig
+++ b/imageroot/actions/create-module/20expandconfig
@@ -35,7 +35,7 @@ events {
 
 http {
     include       /etc/nginx/mime.types;
-    # Set .mjs and wasm that is missing in the mime.types
+    # Set .mjs that is missing in the mime.types
     types {
         text/javascript mjs;
     }


### PR DESCRIPTION
Eliminate the duplicated MIME type entry for WASM in the Nginx configuration to streamline the settings.

https://github.com/NethServer/dev/issues/7206

remove the warning 

```
Dec 10 18:24:28 R1.rocky9.org nextcloud-nginx[35832]: 2024/12/10 17:24:28 [warn] 1#1: duplicate extension "wasm", content type: "application/wasm", previous content type: "application/wasm" in /etc/nginx/nginx.conf:16
Dec 10 18:24:28 R1.rocky9.org nextcloud-nginx[35832]: nginx: [warn] duplicate extension "wasm", content type: "application/wasm", previous content type: "application/wasm" in /etc/nginx/nginx.conf:16
```

wasm is already included in /etc/nginx/mime.types and loaded at [this line ](https://github.com/NethServer/ns8-nextcloud/blob/c82da706eedc09551c24b02fb0c7ebbcb7a2ed44/imageroot/actions/create-module/20expandconfig#L37)

```
/ # grep -srni 'wasm' /etc/nginx/
/etc/nginx/mime.types:55:    application/wasm                                 wasm;
/etc/nginx/nginx.conf:167:        location ~ \.(?:css|js|mjs|svg|gif|ico|jpg|png|webp|wasm|tflite|map|ogg|flac)$ {
```