### PR TITLE
Update Nextcloud version to 29.0.10

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -3,7 +3,7 @@
 # Terminate on error
 set -e
 
-NC_VERSION=28.0.14
+NC_VERSION=29.0.10
 
 # Prepare variables for later use
 images=()


### PR DESCRIPTION
Upgrade the Nextcloud version in the build script to ensure compatibility with the latest features and improvements.

https://github.com/NethServer/dev/issues/7225

First install => OK
upgrade => OK but a warning about missing indexes
Collabora workable with a LE certficate

![image](https://github.com/user-attachments/assets/cbd5b66b-0895-48f8-b67f-acce03e17108)

`The database is missing some indexes. Due to the fact that adding indexes on big tables could take some time they were not added automatically. By running "occ db:add-missing-indices" those missing indexes could be added manually while the instance keeps running. Once the indexes are added queries to those tables are usually much faster. Missing optional index "dav_shares_resourceid_type" in table "dav_shares". Missing optional index "dav_shares_resourceid_access" in table "dav_shares". Missing optional index "oc_npushhash_di" in table "notifications_pushhash". Missing optional index "systag_by_objectid" in table "systemtag_object_mapping".`

Possible fix call in the upgrade actions

`occ db:add-missing-indices`

or document in the documentation to trigger it manually 

`runagent -m nextcloudXX occ db:add-missing-indices`