### PR TITLE
Suppress notify push version mismatch error

### DIFF
--- a/imageroot/actions/configure-module/90apps_management
+++ b/imageroot/actions/configure-module/90apps_management
@@ -14,3 +14,6 @@ occ app:disable logreader
 occ app:install notify_push
 occ app:enable notify_push
 occ -n notify_push:setup http://127.0.0.1/push
+
+# Suppress error when notify push versions do not match, see https://github.com/NethServer/dev/issues/7450
+exit 0


### PR DESCRIPTION
Set "exit 0" in configure-module action `90apps_management` to suppress the version mismatch error.

NethServer/dev#7450