### PR TITLE
Add DB-fix script to fix the Nextcloud database and adapt README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ By adding `LDAP_MAIL_ATTRIBUTE` your users wil be able to login with :
 add : `LDAP_MAIL_ATTRIBUTE=mail`
 `systemctl --user restart nextcloud`
 
+## DB-fix script
+
+Nextcloud needs manual DB fixes which can't be automated on upgrade as database operations might take a long time when there's much data.
+For that case there's a `DB-fix` script that can be executed manually to fix the Nextcloud database outside production times.
+
+    runagent -m nextcloud1 DB-fix
 
 ## Uninstall
 

--- a/imageroot/bin/DB-fix
+++ b/imageroot/bin/DB-fix
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+#!/bin/bash
+
+# Fix row format
+if occ setupchecks | grep -q 'MySQL row format: Incorrect'; then
+  echo "Fix DB row format..."
+  # Create temp sql file
+  tmpsql=$(mktemp dbfix.XXXXXX)
+  trap 'rm -f ${tmpsql}' EXIT
+
+  # Write sql file
+  podman exec nextcloud-db mysql -u nextcloud -pnextcloud -Bse "SELECT CONCAT('ALTER TABLE \`', TABLE_NAME, '\`ROW_FORMAT=DYNAMIC;') FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'nextcloud' AND ENGINE = 'InnoDB';" > ${tmpsql}
+
+  # Execute sql file
+  podman exec -i nextcloud-db mysql -u nextcloud -pnextcloud -D nextcloud < ${tmpsql}
+fi
+
+# Fix mimetype migrations
+occ setupchecks | grep -q 'Mimetype migrations available: One' && occ maintenance:repair --include-expensive
+
+# Fix missing indices
+occ setupchecks | grep -q 'Database missing indices: Detected' && occ db:add-missing-indices
+
+# Fix terminal
+stty sane

--- a/imageroot/bin/DB-fix
+++ b/imageroot/bin/DB-fix
@@ -20,8 +20,6 @@
 # along with NethServer.  If not, see COPYING.
 #
 
-#!/bin/bash
-
 # Fix row format
 if occ setupchecks | grep -q 'MySQL row format: Incorrect'; then
   echo "Fix DB row format..."


### PR DESCRIPTION
Nextcloud needs some manual DB fixes, those are provided by a `DB-fix` script.

The script checks via occ which database fixes are needed and applies them.

The README was adapted to explain the use of the `DB-fix` script.

Refs NethServer/dev#7522