### PR TITLE
Improve status check and error handling in wait-startup script

### DIFF
--- a/imageroot/bin/wait-startup
+++ b/imageroot/bin/wait-startup
@@ -6,7 +6,6 @@
 #
 
 import sys
-import json
 import time
 import subprocess
 
@@ -21,11 +20,14 @@ i = 0
 while i < max_tries:
     i = i+1
     try:
-        ret, out = occ(["status", "--output", "json"])
-        status = json.loads(out)
-        if status["installed"]:
+        ret, out = occ(["status", "-e"])
+        if ret == 0:
             break
-        print(f"wait-startup: waiting for nextcloud-app ({i})", file=sys.stderr)
-        time.sleep(1)
+        status_msg = {1: "maintenance mode enabled", 2: "needs DB upgrade"}.get(ret, "not ready")
+        print(f"wait-startup: waiting for nextcloud-app ({i}): occ status exit code={ret} ({status_msg})", file=sys.stderr)
     except Exception as e:
-        continue
+        print(f"wait-startup: exception ({i}): {e}", file=sys.stderr)
+    time.sleep(1)
+else:
+    print("wait-startup: Nextcloud did not become ready in time", file=sys.stderr)
+    sys.exit(1)

--- a/imageroot/bin/wait-startup
+++ b/imageroot/bin/wait-startup
@@ -17,10 +17,12 @@ def occ(args):
 # wait after nextcloud-app is ready
 max_tries = 60
 i = 0
+last_ret = None
 while i < max_tries:
     i = i+1
     try:
         ret, out = occ(["status", "-e"])
+        last_ret = ret
         if ret == 0:
             break
         status_msg = {1: "maintenance mode enabled", 2: "needs DB upgrade"}.get(ret, "not ready")
@@ -29,5 +31,6 @@ while i < max_tries:
         print(f"wait-startup: exception ({i}): {e}", file=sys.stderr)
     time.sleep(1)
 else:
-    print("wait-startup: Nextcloud did not become ready in time", file=sys.stderr)
+    status_msg = {1: "maintenance mode enabled", 2: "needs DB upgrade"}.get(last_ret, "not ready")
+    print(f"wait-startup: Nextcloud did not become ready in time (last status: {status_msg})", file=sys.stderr)
     sys.exit(1)

--- a/imageroot/bin/wait-startup
+++ b/imageroot/bin/wait-startup
@@ -15,6 +15,7 @@ def occ(args):
     return (p.returncode, p.stdout)
 
 # wait after nextcloud-app is ready
+exit_code_messages = {1: "maintenance mode enabled", 2: "needs DB upgrade"}
 max_tries = 60
 i = 0
 last_ret = None
@@ -25,12 +26,12 @@ while i < max_tries:
         last_ret = ret
         if ret == 0:
             break
-        status_msg = {1: "maintenance mode enabled", 2: "needs DB upgrade"}.get(ret, "not ready")
+        status_msg = exit_code_messages.get(ret, "not ready")
         print(f"wait-startup: waiting for nextcloud-app ({i}): occ status exit code={ret} ({status_msg})", file=sys.stderr)
     except Exception as e:
         print(f"wait-startup: exception ({i}): {e}", file=sys.stderr)
     time.sleep(1)
 else:
-    status_msg = {1: "maintenance mode enabled", 2: "needs DB upgrade"}.get(last_ret, "not ready")
+    status_msg = exit_code_messages.get(last_ret, "not ready")
     print(f"wait-startup: Nextcloud did not become ready in time (last status: {status_msg})", file=sys.stderr)
     sys.exit(1)


### PR DESCRIPTION
Enhance the wait-startup script by improving the status check and error handling mechanisms. The script now provides clearer output messages based on the exit code of the status command and handles exceptions more effectively.

- Refs https://github.com/NethServer/dev/issues/7988


see https://docs.nextcloud.com/server/30/admin_manual/configuration_server/occ_command.html#status