### PR TITLE
Include upstream name in version display

### DIFF
--- a/ui/src/views/About.vue
+++ b/ui/src/views/About.vue
@@ -56,7 +56,7 @@
             </div>
             <div class="key-value-setting">
               <span class="label">{{ core.$t("common.version") }}</span>
-              <span class="value">{{ version }}</span>
+              <span class="value">{{ version }} ({{ app.upstream_name }})</span>
             </div>
             <div class="key-value-setting">
               <span class="label">{{


### PR DESCRIPTION
Display the upstream name alongside the version in the About page for better clarity.