### PR TITLE
Update CardDAV and CalDAV redirect URLs to HTTPS

### DIFF
--- a/imageroot/actions/create-module/20expandconfig
+++ b/imageroot/actions/create-module/20expandconfig
@@ -147,8 +147,9 @@ http {
             # The rules in this block are an adaptation of the rules
             # in `.htaccess` that concern `/.well-known`.
 
-            location = /.well-known/carddav { return 301 https://$host/remote.php/dav/; }
-            location = /.well-known/caldav  { return 301 https://$host/remote.php/dav/; }
+            absolute_redirect = off;
+            location = /.well-known/carddav { return 301 /remote.php/dav/; }
+            location = /.well-known/caldav  { return 301 /remote.php/dav/; }
 
             location /.well-known/acme-challenge    { try_files $uri $uri/ =404; }
             location /.well-known/pki-validation    { try_files $uri $uri/ =404; }

--- a/imageroot/actions/create-module/20expandconfig
+++ b/imageroot/actions/create-module/20expandconfig
@@ -147,7 +147,7 @@ http {
             # The rules in this block are an adaptation of the rules
             # in `.htaccess` that concern `/.well-known`.
 
-            absolute_redirect = off;
+            absolute_redirect off;
             location = /.well-known/carddav { return 301 /remote.php/dav/; }
             location = /.well-known/caldav  { return 301 /remote.php/dav/; }
 

--- a/imageroot/actions/create-module/20expandconfig
+++ b/imageroot/actions/create-module/20expandconfig
@@ -147,8 +147,8 @@ http {
             # The rules in this block are an adaptation of the rules
             # in `.htaccess` that concern `/.well-known`.
 
-            location = /.well-known/carddav { return 301 /remote.php/dav/; }
-            location = /.well-known/caldav  { return 301 /remote.php/dav/; }
+            location = /.well-known/carddav { return 301 https://$host/remote.php/dav/; }
+            location = /.well-known/caldav  { return 301 https://$host/remote.php/dav/; }
 
             location /.well-known/acme-challenge    { try_files $uri $uri/ =404; }
             location /.well-known/pki-validation    { try_files $uri $uri/ =404; }


### PR DESCRIPTION
Update the redirect URLs for CardDAV and CalDAV to ensure they use HTTPS for improved security.

https://github.com/NethServer/dev/issues/8043