### PR TITLE
fix(systemd): replace %S with %E in unit files

### DIFF
--- a/imageroot/systemd/user/nextcloud-app.service
+++ b/imageroot/systemd/user/nextcloud-app.service
@@ -6,7 +6,7 @@ After=nextcloud.service nextcloud-db.service nextcloud-redis.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 TimeoutStopSec=90
 ExecStartPre=/bin/rm -f %t/nextcloud-app.pid %t/nextcloud-app.ctr-id
@@ -14,7 +14,7 @@ ExecStartPre=-runagent discover-smarthost
 ExecStartPost=runagent wait-startup
 ExecStartPost=runagent setup-smtp
 ExecStartPost=runagent setup-ldap
-ExecStart=/usr/bin/podman run --conmon-pidfile %t/nextcloud-app.pid --cidfile %t/nextcloud-app.ctr-id --cgroups=no-conmon --pod-id-file %t/nextcloud.pod-id --replace -d --name nextcloud-app --env-file=%S/state/config.env --env-file=%S/state/smarthost.env -v nextcloud-app-data:/var/www/html -v %S/state/zzz_nethserver.conf:/usr/local/etc/php-fpm.d/zzz_nethserver.conf:z ${NEXTCLOUD_APP_IMAGE}
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/nextcloud-app.pid --cidfile %t/nextcloud-app.ctr-id --cgroups=no-conmon --pod-id-file %t/nextcloud.pod-id --replace -d --name nextcloud-app --env-file=%E/state/config.env --env-file=%E/state/smarthost.env -v nextcloud-app-data:/var/www/html -v %E/state/zzz_nethserver.conf:/usr/local/etc/php-fpm.d/zzz_nethserver.conf:z ${NEXTCLOUD_APP_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/nextcloud-app.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/nextcloud-app.ctr-id
 PIDFile=%t/nextcloud-app.pid

--- a/imageroot/systemd/user/nextcloud-db.service
+++ b/imageroot/systemd/user/nextcloud-db.service
@@ -5,12 +5,12 @@ Before=nextcloud-app.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/nextcloud-db.pid %t/nextcloud-db.ctr-id
-ExecStartPre=/bin/mkdir -p %S/state/restore/
-ExecStart=/usr/bin/podman run --conmon-pidfile %t/nextcloud-db.pid --cidfile %t/nextcloud-db.ctr-id --cgroups=no-conmon --pod-id-file %t/nextcloud.pod-id --replace -d --name nextcloud-db --env-file=%S/state/database.env  -v nextcloud-db-data:/var/lib/mysql -v %S/state/restore/:/docker-entrypoint-initdb.d/:z ${MARIADB_IMAGE}
+ExecStartPre=/bin/mkdir -p %E/state/restore/
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/nextcloud-db.pid --cidfile %t/nextcloud-db.ctr-id --cgroups=no-conmon --pod-id-file %t/nextcloud.pod-id --replace -d --name nextcloud-db --env-file=%E/state/database.env  -v nextcloud-db-data:/var/lib/mysql -v %E/state/restore/:/docker-entrypoint-initdb.d/:z ${MARIADB_IMAGE}
 ExecStartPost=/bin/bash -c "until /usr/bin/podman exec nextcloud-db mariadb-admin ping -uroot -p$$MARIADB_ROOT_PASSWORD --silent --protocol=tcp --port=3306 2>/dev/null; do sleep 1; done"
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/nextcloud-db.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/nextcloud-db.ctr-id

--- a/imageroot/systemd/user/nextcloud-nginx.service
+++ b/imageroot/systemd/user/nextcloud-nginx.service
@@ -5,11 +5,11 @@ After=nextcloud-app.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/nextcloud-.pid %t/nextcloud-nginx.ctr-id
-ExecStart=/usr/bin/podman run --conmon-pidfile %t/nextcloud-nginx.pid --cidfile %t/nextcloud-nginx.ctr-id --cgroups=no-conmon --pod-id-file %t/nextcloud.pod-id --replace -d --name nextcloud-nginx --env-file=%S/state/config.env -v %S/state/nginx.conf:/etc/nginx/nginx.conf:ro,Z --volumes-from nextcloud-app:rw,z ${NGINX_IMAGE}
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/nextcloud-nginx.pid --cidfile %t/nextcloud-nginx.ctr-id --cgroups=no-conmon --pod-id-file %t/nextcloud.pod-id --replace -d --name nextcloud-nginx --env-file=%E/state/config.env -v %E/state/nginx.conf:/etc/nginx/nginx.conf:ro,Z --volumes-from nextcloud-app:rw,z ${NGINX_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/nextcloud-nginx.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/nextcloud-nginx.ctr-id
 PIDFile=%t/nextcloud-nginx.pid

--- a/imageroot/systemd/user/nextcloud-notify_push.service
+++ b/imageroot/systemd/user/nextcloud-notify_push.service
@@ -4,7 +4,7 @@ After=nextcloud-app.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/nextcloud-notify_push.pid %t/nextcloud-notify_push.ctr-id
@@ -12,7 +12,7 @@ ExecStartPre=runagent setup-notify_push
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/nextcloud-notify_push.pid --cidfile %t/nextcloud-notify_push.ctr-id --cgroups=no-conmon \
   --pod-id-file %t/nextcloud.pod-id \
   --replace -d --name nextcloud-notify_push \
-  --env-file %S/state/notify_push.env \
+  --env-file %E/state/notify_push.env \
    ${NEXTCLOUD_NOTIFY_PUSH_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/nextcloud-notify_push.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/nextcloud-notify_push.ctr-id

--- a/imageroot/systemd/user/nextcloud-redis.service
+++ b/imageroot/systemd/user/nextcloud-redis.service
@@ -4,7 +4,7 @@ Before=nextcloud-app.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/nextcloud-redis.pid %t/nextcloud-redis.ctr-id

--- a/imageroot/systemd/user/nextcloud.service
+++ b/imageroot/systemd/user/nextcloud.service
@@ -4,7 +4,7 @@ Before=nextcloud-app.service nextcloud-db.service nextcloud-redis.service nextcl
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/nextcloud.pid %t/nextcloud.pod-id


### PR DESCRIPTION
## Summary
- Newer systemd releases (Rocky Linux 9.8+, Debian 13) changed the `%S` specifier to expand to `~/.local/state` instead of `~/.config`, breaking units that relied on the old behavior to reference the config/state directory.
- Replaced `%S` with `%E` across all affected systemd user unit files. `%E` expands to `~/.config` on both old and new systemd, making the units forward-compatible.

Related: NethServer/dev#8029

## Test plan
- [ ] Verify units still parse (`systemd-analyze verify`) on a test node
- [ ] Confirm services start correctly on both an old (Rocky 9.x pre-9.8) and new (Rocky 9.8+/Debian 13) systemd host